### PR TITLE
Adding support for generating unique numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ app.post('/url-to-a-route-or-worker', asyncHandler(async (req, res) => {
   * The below can be used both at the install level or global level
   */
   await installStorage.set('foo', 'bar'); // sets foo=bar in storage for this install
-  const { value } = await installStorage.setUnique('foo'); // creates and returns a unique value for foo
+  const { value } = await installStorage.setUnique('foo'); // creates and returns a unique text value for foo
+  const { value } = await installStorage.setUniqueNum('foo'); // creates and returns a unique number for foo
   const { value } = await installStorage.get('foo'); // also gets the current value of foo
   await installStorage.unset('foo'); // deletes foo
   /**

--- a/lib/EnvoyPluginStorage.js
+++ b/lib/EnvoyPluginStorage.js
@@ -12,6 +12,12 @@ const EnvoyPluginStoragePipeline = require('./EnvoyPluginStoragePipeline');
  * @property {number} size=12 - the length of the value
  */
 
+/**
+ * @typedef {Object} UniqueNumOptions
+ * @property {number} min=0 - the minimum number to pick from
+ * @property {number} max=Number.MAX_SAFE_INTEGER - the maximum number to pick from
+ */
+
 class EnvoyPluginStorage {
 
   /**
@@ -73,6 +79,18 @@ class EnvoyPluginStorage {
   setUnique(key, options = {}) {
 
     return this.pipeline().setUnique(key, options).executeSingle();
+  }
+
+  /**
+   * Wrapper for single pipeline setUnique.
+   *
+   * @param {string} key
+   * @param {UniqueNumOptions} [options]
+   * @returns {Promise<PluginStorageItem>}
+   */
+  setUniqueNum(key, options = {}) {
+
+    return this.pipeline().setUniqueNum(key, options).executeSingle();
   }
 
   /**

--- a/lib/EnvoyPluginStoragePipeline.js
+++ b/lib/EnvoyPluginStoragePipeline.js
@@ -16,6 +16,12 @@
  * @property {number} size=12 - the length of the value
  */
 
+/**
+ * @typedef {Object} UniqueNumOptions
+ * @property {number} min=0 - the minimum number to pick from
+ * @property {number} max=Number.MAX_SAFE_INTEGER - the maximum number to pick from
+ */
+
 class EnvoyPluginStoragePipeline {
 
   /**
@@ -106,6 +112,19 @@ class EnvoyPluginStoragePipeline {
   setUnique(key, options = {}) {
 
     return this.addCommand(Object.assign({ action: 'set_unique', key }, options));
+  }
+
+  /**
+   * Sets a unique number value for a storage item,
+   * and returns that item.
+   *
+   * @param {string} key
+   * @param {UniqueNumOptions} [options]
+   * @returns {EnvoyPluginStoragePipeline}
+   */
+  setUniqueNum(key, options = {}) {
+
+    return this.addCommand(Object.assign({ action: 'set_unique_num', key }, options));
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "envoy-integrations-sdk-nodejs",
+  "name": "@envoy/envoy-integrations-sdk",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envoy/envoy-integrations-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds another feature to plugin storage: to generate unique numbers for a key. This is useful for our newer efforts to generate card numbers for access control integrations.

Corresponds to the back-end change here: https://github.com/envoy/envoy-web/pull/10487