### PR TITLE
Enable public api

### DIFF
--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -352,9 +352,30 @@ class EnvoyAPI {
     })
 
     // Currently the route returns only a status code 204 for success. For now just return object indicating success.
-    return { "message" : "Success" };
+    return { "message": "Success" };
   }
 
+  /**
+   * Fetches a WorkSchedule.
+   * @param { number | string } workSchedule Id.
+   */
+  async workSchedule(workScheduleId) {
+    var options = {
+      method: 'GET',
+      url: `https://api.envoy.com/v1/work-schedules/${workScheduleId}`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true,
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
 
   /**
    * Fetches a list of WorkSchedules.
@@ -362,10 +383,10 @@ class EnvoyAPI {
    */
   async workSchedules(workSchedule) {
     var options = {
-      'method': 'GET',
-      'url': 'https://api.envoy.com/v1/work-schedules',
-      'headers': {
-        'Authorization': 'Bearer ' + this.token
+      method: 'GET',
+      url: 'https://api.envoy.com/v1/work-schedules',
+      headers: {
+        Authorization: 'Bearer ' + this.token
       },
       body: workSchedule,
       json: true,
@@ -384,10 +405,19 @@ class EnvoyAPI {
    * @param {{}} workSchedule - Work object with locationId, email, expectedArrivalAt (UTC date time format)
    */
   async createWorkSchedule(workSchedule) {
-    const body = await this.request({
+    var options = {
       method: 'POST',
-      url: `/api/v1/work-schedules`,
+      url: `https://api.envoy.com/v1/work-schedules`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
       body: workSchedule,
+      json: true,
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
     });
 
     return EnvoyAPI.getDataFromBody(body);

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -431,7 +431,7 @@ class EnvoyAPI {
    * @param {{}} workSchedule object.
    * @returns {Promise<EnvoyObject>}
    */
-   deleteWorkSchedule = async (workScheduleId) => {
+  deleteWorkSchedule = async (workScheduleId) => {
     var options = {
       method: 'DELETE',
       url: `https://api.envoy.com/v1/work-schedules/${workScheduleId}`,
@@ -446,9 +446,57 @@ class EnvoyAPI {
       if (error) throw new Error(error);
       response.body;
     });
-    
+
     body.message = "Work Schedule has been removed.";
     return body;
+  }
+
+  /**
+   * Check in a certain work schedule item.
+   * @param { number | string } workSchedule Id
+   * @returns {Promise<EnvoyObject>}
+   */
+  async checkInWork(workScheduleId) {
+    var options = {
+      method: 'POST',
+      url: `https://api.envoy.com/v1/work-schedules/${workScheduleId}/checkin`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    // Returns status 204 so body has no content.
+    return { message: 'Successfully checked in.' }
+  }
+
+  /**
+   * Check out a certain work schedule item.
+   * @param { number | string } workSchedule Id
+   * @returns {Promise<EnvoyObject>}
+   */
+   async checkOutWork(workScheduleId) {
+    var options = {
+      method: 'POST',
+      url: `https://api.envoy.com/v1/work-schedules/${workScheduleId}/checkout`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    // Returns status 204 so body has no content.
+    return { message: 'Successfully checked out.' }
   }
 
   /**

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -88,7 +88,7 @@ class EnvoyAPI {
 
     return EnvoyAPI.getDataFromBody(body);
   }
-  
+
   async locations() {
 
     const body = await this.request({
@@ -97,7 +97,7 @@ class EnvoyAPI {
 
     return EnvoyAPI.getDataFromBody(body);
   }
-  
+
   async location(locationId) {
 
     const body = await this.request({
@@ -106,11 +106,33 @@ class EnvoyAPI {
 
     return EnvoyAPI.getDataFromBody(body);
   }
-  
+
   async company() {
 
     const body = await this.request({
       url: '/api/v1/companies',
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+  /**
+   * Retrieve details about an organization or account.
+   * @returns {Promise<EnvoyObject[]>}
+   */
+  async companies() {
+    var options = {
+      'method': 'GET',
+      'url': 'https://api.envoy.com/v1/companies',
+      'headers': {
+        'Authorization': 'Bearer ' + this.token
+      },
+      json: true,
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
     });
 
     return EnvoyAPI.getDataFromBody(body);
@@ -246,7 +268,7 @@ class EnvoyAPI {
       'method': 'GET',
       'url': 'https://api.envoy.com/v1/work-schedules',
       'headers': {
-          'Authorization': 'Bearer ' + this.token
+        'Authorization': 'Bearer ' + this.token
       },
       json: true,
     };

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -237,6 +237,20 @@ class EnvoyAPI {
   }
 
   /**
+   * 
+   * @param {{}} workSchedule - Work object with locationId, email, expectedArrivalAt (UTC date time format)
+   */
+  async workSchedule(workSchedule) {
+    const body = await this.request({
+      method: 'POST',
+      url: `/api/v1/work-schedules`,
+      body: workSchedule,
+    });
+    
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+  /**
    * Creates an invite.
    *
    * @param {{}} invite

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -165,6 +165,35 @@ class EnvoyAPI {
     return EnvoyAPI.getDataFromBody(body);
   }
 
+
+  /**
+   * Import employee records to the Employee Directory. The file headers must be in the following order, Full Name, Email, Mobile Number, Assistants Email. 
+   * If your csv does not contain email entries, it will override the previous employee directory in full.
+   * Possibly deprecated? This route doesn't seem to exist anymore.
+   * @param {file} file 
+   * @param {string} api_key 
+   * @returns 
+   */
+  async importEmployeeRecords(file, api_key) {
+    var options = {
+      'method': 'GET',
+      'url': `https://app.envoy.com/api/configuration/employee_list/${api_key}`,
+      'headers': {
+        'Authorization': 'Bearer ' + this.token
+      },
+      body: file,
+      json: true,
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+
   /**
    * Fetches the employees for this location.
    *
@@ -260,13 +289,13 @@ class EnvoyAPI {
   }
 
   /**
-   * Fetches a list of WorkSchedules.
-   * @param {{}} workSchedule object.
+   * Fetches an entry by id.
+   * @param {string | number}} Entry Id
    */
-  async workSchedules(workSchedule) {
+  async entry(entryId) {
     var options = {
       'method': 'GET',
-      'url': 'https://api.envoy.com/v1/work-schedules',
+      'url': `https://app.envoy.com/a/visitors/api/v2/entries/${entryId}`,
       'headers': {
         'Authorization': 'Bearer ' + this.token
       },
@@ -280,6 +309,30 @@ class EnvoyAPI {
 
     return EnvoyAPI.getDataFromBody(body);
   }
+
+  /**
+   * Fetches a list of WorkSchedules.
+   * @param {{}} workSchedule object.
+   */
+  async workSchedules(workSchedule) {
+    var options = {
+      'method': 'GET',
+      'url': 'https://api.envoy.com/v1/work-schedules',
+      'headers': {
+        'Authorization': 'Bearer ' + this.token
+      },
+      body: workSchedule,
+      json: true,
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
   /**
    * Create a new work schedule for an employee.
    * @param {{}} workSchedule - Work object with locationId, email, expectedArrivalAt (UTC date time format)

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -49,9 +49,8 @@ class EnvoyAPI {
     this.token = token;
     this.baseUrl = process.env.ENVOY_BASE_URL || 'https://app.envoy.com';
     this.newUrl = 'https://api.envoy.com/v1';
-    /*
-      Request library is deprecated as of 2020, we should update to another REST library soon.
-    */
+
+    //Request library is deprecated as of 2020. Proposing that we use Axios for future requests.
     this.request = request.defaults({
       headers: {
         Authorization: `Bearer ${token}`,
@@ -65,17 +64,18 @@ class EnvoyAPI {
 
     /* 
       Setting ENVOY_BASE_URL in .env to point to the new API endpoint will break some methods below relying on the old route. 
-      A temporary workaround for now is to set a new Request default with the updated endpoint.
+      A temporary workaround for now is to set a new axios default with the updated endpoint.
     */
-    // this.requestNewRoute = request.defaults({
+    // this.axios = axios.create({
     //   headers: {
-    //     Authorization: `Bearer ${token}`,
-    //     'Content-Type': 'application/vnd.api+json',
-    //     Accept: 'application/vnd.api+json',
-    //     'X-Envoy-Context': JSON.stringify(xEnvoyContext),
+    //     common: {
+    //       Authorization: `Bearer ${token}`,
+    //       'Content-Type': 'application/vnd.api+json',
+    //       Accept: 'application/vnd.api+json',
+    //       'X-Envoy-Context': JSON.stringify(xEnvoyContext)
+    //     }
     //   },
-    //   json: true,
-    //   baseUrl: this.newUrl,
+    //   baseURL: this.newUrl,
     // })
   }
 
@@ -143,11 +143,11 @@ class EnvoyAPI {
   async companies() {
     var options = {
       method: 'GET',
-      url: this.newUrl + '/companies',
+      url: this.newUrl + `/companies`,
       headers: {
         Authorization: 'Bearer ' + this.token
       },
-      json: true,
+      json: true
     };
 
     const body = await request(options, function (error, response) {
@@ -500,7 +500,7 @@ class EnvoyAPI {
    * @param { number | string } workSchedule Id
    * @returns {Promise<EnvoyObject>}
    */
-   async checkOutWork(workScheduleId) {
+  async checkOutWork(workScheduleId) {
     var options = {
       method: 'POST',
       url: this.newUrl + `/work-schedules/${workScheduleId}/checkout`,
@@ -523,7 +523,7 @@ class EnvoyAPI {
    * @param { number|string } Invite ID.
    * @returns {Promise<EnvoyObject>}
    */
-   async getInvite(inviteId) {
+  async getInvite(inviteId) {
     var options = {
       method: 'GET',
       url: this.newUrl + `/invites/${inviteId}`,
@@ -537,7 +537,7 @@ class EnvoyAPI {
       if (error) throw new Error(error);
       response.body;
     });
-    
+
     return EnvoyAPI.getDataFromBody(body);
   }
 
@@ -546,7 +546,7 @@ class EnvoyAPI {
    * @param { {} } invite Object containing query params. See invites API documentation for list of all possbile Query params.
    * @returns {Promise<EnvoyObject>}
    */
-  async getInvites(invite){
+  async getInvites(invite) {
     var options = {
       method: 'GET',
       url: this.newUrl + `/invites`,
@@ -561,7 +561,7 @@ class EnvoyAPI {
       if (error) throw new Error(error);
       response.body;
     });
-    
+
     return EnvoyAPI.getDataFromBody(body);
   }
 
@@ -581,7 +581,7 @@ class EnvoyAPI {
 
     return EnvoyAPI.getDataFromBody(body);
   }
-  
+
   /**
    * Create an invite using the V1 API endpoint.
    *
@@ -633,7 +633,7 @@ class EnvoyAPI {
    * @param {{}} invite
    * @returns {Promise<EnvoyObject>}
    */
-   async updateInviteV1(inviteId, invite) {
+  async updateInviteV1(inviteId, invite) {
     var options = {
       method: 'POST',
       url: this.newUrl + `/invites/${inviteId}`,
@@ -691,7 +691,7 @@ class EnvoyAPI {
    * @param { number|string } inviteId
    * @returns {Promise<EnvoyObject>}
    */
-   async removeInviteV1(inviteId) {
+  async removeInviteV1(inviteId) {
     var options = {
       method: 'DELETE',
       url: this.newUrl + `/invites/${inviteId}`,
@@ -708,7 +708,145 @@ class EnvoyAPI {
 
     return EnvoyAPI.getDataFromBody(body);
   }
-  
+
+  /**
+   * Get a reservation by Id.
+   * @params { number|string }
+   * @returns {Promise<EnvoyObject[]>}
+   */
+  async reservation(resId) {
+    var options = {
+      method: 'GET',
+      url: this.newUrl + `/reservations/${resId}`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+  /**
+   * Get reservations.
+   * @returns {Promise<EnvoyObject[]>}
+   */
+  async reservations(resParams) {
+    var options = {
+      method: 'GET',
+      url: this.newUrl + `/reservations`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+  /**
+   * Create a reservation
+   * @params { {} } A reservation object containing body params.
+   * @returns {Promise<EnvoyObject[]>}
+   */
+  async createReservation(reservation) {
+    var options = {
+      method: 'POST',
+      url: this.newUrl + `/reservations`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      body: reservation,
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+  /**
+   * Check in a reservation
+   * @params { number|string } Reservation Id.
+   * @returns {Promise<EnvoyObject[]>}
+   */
+  async checkInReservation(resId) {
+    var options = {
+      method: 'POST',
+      url: this.newUrl + `/reservations/${resId}/checkin`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+  /**
+   * Check out a reservation
+   * @params { number|string } Reservation Id.
+   * @returns {Promise<EnvoyObject[]>}
+   */
+  async checkOutReservation(resId) {
+    var options = {
+      method: 'POST',
+      url: this.newUrl + `/reservations/${resId}/checkout`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+  /**
+   * Cancel a reservation
+   * @params { number|string } Reservation Id.
+   * @returns {Promise<EnvoyObject[]>}
+   */
+  async cancelReservation(resId) {
+    var options = {
+      method: 'POST',
+      url: this.newUrl + `/reservations/${resId}/cancel`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
   /**
    * Updates the job.
    *

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -45,6 +45,7 @@ class EnvoyAPI {
       throw new Error('No token supplied.');
     }
 
+    this.token = token;
     this.baseUrl = process.env.ENVOY_BASE_URL || 'https://app.envoy.com';
     this.request = request.defaults({
       headers: {
@@ -109,7 +110,7 @@ class EnvoyAPI {
   async company() {
 
     const body = await this.request({
-      url: '/api/v2/companies',
+      url: '/api/v1/companies',
     });
 
     return EnvoyAPI.getDataFromBody(body);
@@ -238,13 +239,21 @@ class EnvoyAPI {
 
   /**
    * Fetches a list of WorkSchedules.
-   * @param {*} workSchedule 
+   * @param {{}} workSchedule object.
    */
   async workSchedules(workSchedule) {
-    const body = await this.request({
-      method: 'GET',
-      url: `/api/v1/work-schedules`,
-      body: workSchedule,
+    var options = {
+      'method': 'GET',
+      'url': 'https://api.envoy.com/v1/work-schedules',
+      'headers': {
+          'Authorization': 'Bearer ' + this.token
+      },
+      json: true,
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
     });
 
     return EnvoyAPI.getDataFromBody(body);

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -583,7 +583,7 @@ class EnvoyAPI {
   
   async createInviteV1(invite) {
     var options = {
-      method: 'GET',
+      method: 'POST',
       url: this.newUrl + `/invites`,
       headers: {
         Authorization: 'Bearer ' + this.token
@@ -596,6 +596,8 @@ class EnvoyAPI {
       if (error) throw new Error(error);
       response.body;
     });
+
+    return EnvoyAPI.getDataFromBody(body);
   }
   
   /**

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -237,16 +237,16 @@ class EnvoyAPI {
   }
 
   /**
-   * 
+   * Create a new work schedule for an employee.
    * @param {{}} workSchedule - Work object with locationId, email, expectedArrivalAt (UTC date time format)
    */
-  async workSchedule(workSchedule) {
+  async createWorkSchedule(workSchedule) {
     const body = await this.request({
       method: 'POST',
       url: `/api/v1/work-schedules`,
       body: workSchedule,
     });
-    
+
     return EnvoyAPI.getDataFromBody(body);
   }
 

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -358,6 +358,7 @@ class EnvoyAPI {
   /**
    * Fetches a WorkSchedule.
    * @param { number | string } workSchedule Id.
+   * @returns {Promise<EnvoyObject>}
    */
   async workSchedule(workScheduleId) {
     var options = {
@@ -380,6 +381,7 @@ class EnvoyAPI {
   /**
    * Fetches a list of WorkSchedules.
    * @param {{}} workSchedule object.
+   * @returns {Promise<EnvoyObject>}
    */
   async workSchedules(workSchedule) {
     var options = {
@@ -403,6 +405,7 @@ class EnvoyAPI {
   /**
    * Create a new work schedule for an employee.
    * @param {{}} workSchedule - Work object with locationId, email, expectedArrivalAt (UTC date time format)
+   * @returns {Promise<EnvoyObject>}
    */
   async createWorkSchedule(workSchedule) {
     var options = {
@@ -421,6 +424,31 @@ class EnvoyAPI {
     });
 
     return EnvoyAPI.getDataFromBody(body);
+  }
+
+  /**
+   * Deletes a work schedule item. Returns prev item to be deleted on success.
+   * @param {{}} workSchedule object.
+   * @returns {Promise<EnvoyObject>}
+   */
+   deleteWorkSchedule = async (workScheduleId) => {
+    var options = {
+      method: 'DELETE',
+      url: `https://api.envoy.com/v1/work-schedules/${workScheduleId}`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true
+    };
+
+    const body = await this.workSchedule(workScheduleId);
+    await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+    
+    body.message = "Work Schedule has been removed.";
+    return body;
   }
 
   /**

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -48,6 +48,9 @@ class EnvoyAPI {
     this.token = token;
     this.baseUrl = process.env.ENVOY_BASE_URL || 'https://app.envoy.com';
     this.newUrl = 'https://api.envoy.com/v1';
+    /*
+      Request library is deprecated as of 2020, we should update to another REST library soon.
+    */
     this.request = request.defaults({
       headers: {
         Authorization: `Bearer ${token}`,
@@ -58,6 +61,21 @@ class EnvoyAPI {
       json: true,
       baseUrl: this.baseUrl,
     });
+
+    /* 
+      Setting ENVOY_BASE_URL in .env to point to the new API endpoint will break some methods below relying on the old route. 
+      A temporary workaround for now is to set a new Request default with the updated endpoint.
+    */
+    // this.requestNewRoute = request.defaults({
+    //   headers: {
+    //     Authorization: `Bearer ${token}`,
+    //     'Content-Type': 'application/vnd.api+json',
+    //     Accept: 'application/vnd.api+json',
+    //     'X-Envoy-Context': JSON.stringify(xEnvoyContext),
+    //   },
+    //   json: true,
+    //   baseUrl: this.newUrl,
+    // })
   }
 
   /**
@@ -123,10 +141,10 @@ class EnvoyAPI {
    */
   async companies() {
     var options = {
-      'method': 'GET',
-      'url': this.newUrl + '/companies',
-      'headers': {
-        'Authorization': 'Bearer ' + this.token
+      method: 'GET',
+      url: this.newUrl + '/companies',
+      headers: {
+        Authorization: 'Bearer ' + this.token
       },
       json: true,
     };
@@ -524,7 +542,7 @@ class EnvoyAPI {
 
 
   /**
-   * @param { {} } invite Object containing query params. 
+   * @param { {} } invite Object containing query params. See invites API documentation for list of all possbile Query params.
    * @returns {Promise<EnvoyObject>}
    */
   async getInvites(invite){
@@ -562,7 +580,24 @@ class EnvoyAPI {
 
     return EnvoyAPI.getDataFromBody(body);
   }
+  
+  async createInviteV1(invite) {
+    var options = {
+      method: 'GET',
+      url: this.newUrl + `/invites`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      body: invite,
+      json: true
+    };
 
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+  }
+  
   /**
    * Updates an invite.
    *

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -300,6 +300,31 @@ class EnvoyAPI {
 
     return EnvoyAPI.getDataFromBody(body);
   }
+
+  /**
+   * 
+   * @param {*} entry Query params in addition to dates to filter by.
+   * entry = {
+   *  location: { number },
+   *  limit: { number },
+   *  offset: { number },
+   *  start_date: { string },
+   *  end_date: { string }
+   * }
+   * 
+   * start_date: '1900-01-31' (Example date String, same format for end_date)      
+   * @returns {Promise<EnvoyObject>}
+   */
+  async getEntriesByDate(entry) {
+    let params = `?filter[location]=${entry.location}&page[limit]=${entry.limit}&page[offset]=${entry.offset}&start_date=${entry.start_date}&end_date=${entry.end_date}`
+    const body = await this.request({
+      method: 'GET',
+      url: `/a/visitors/api/v2/entries/${params}`
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
   /** 
    * @param {string | number} entryId
    * @param {{}} entry

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -609,11 +609,30 @@ class EnvoyAPI {
   /**
    * Updates an invite.
    *
+   * @param inviteId
+   * @param {{}} invite
+   * @returns {Promise<EnvoyObject>}
+   */
+  async updateInvite(inviteId, invite) {
+
+    // eslint-disable-next-line no-param-reassign
+    invite.data.id = inviteId;
+    const body = await this.request({
+      method: 'PUT',
+      url: `/api/v3/invites/${inviteId}`,
+      body: invite,
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+  /**
+   * Updates an invite using the V1 API endpoint.
+   *
    * @param { number|string } inviteId
    * @param {{}} invite
    * @returns {Promise<EnvoyObject>}
    */
-  async updateInviteV1(inviteId, invite) {
+   async updateInviteV1(inviteId, invite) {
     var options = {
       method: 'POST',
       url: this.newUrl + `/invites/${inviteId}`,
@@ -627,26 +646,6 @@ class EnvoyAPI {
     const body = await request(options, function (error, response) {
       if (error) throw new Error(error);
       response.body;
-    });
-
-    return EnvoyAPI.getDataFromBody(body);
-  }
-
-  /**
-   * Updates an invite.
-   *
-   * @param inviteId
-   * @param {{}} invite
-   * @returns {Promise<EnvoyObject>}
-   */
-  async updateInvite(inviteId, invite) {
-
-    // eslint-disable-next-line no-param-reassign
-    invite.data.id = inviteId;
-    const body = await this.request({
-      method: 'PUT',
-      url: `/api/v3/invites/${inviteId}`,
-      body: invite,
     });
 
     return EnvoyAPI.getDataFromBody(body);
@@ -673,7 +672,7 @@ class EnvoyAPI {
   }
 
   /**
-   * Removes an invite.
+   * Removes an invite
    *
    * @param inviteId
    * @returns {Promise<void>}
@@ -685,6 +684,30 @@ class EnvoyAPI {
     });
   }
 
+  /**
+   * Removes an invite using the V1 API endpoint.
+   *
+   * @param { number|string } inviteId
+   * @returns {Promise<EnvoyObject>}
+   */
+   async removeInviteV1(inviteId) {
+    var options = {
+      method: 'DELETE',
+      url: this.newUrl + `/invites/${inviteId}`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+  
   /**
    * Updates the job.
    *

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -293,22 +293,43 @@ class EnvoyAPI {
    * @param {string | number}} Entry Id
    */
   async entry(entryId) {
-    var options = {
-      'method': 'GET',
-      'url': `https://app.envoy.com/a/visitors/api/v2/entries/${entryId}`,
-      'headers': {
-        'Authorization': 'Bearer ' + this.token
-      },
-      json: true,
-    };
-
-    const body = await request(options, function (error, response) {
-      if (error) throw new Error(error);
-      response.body;
+    const body = await this.request({
+      method: 'GET',
+      url: `/a/visitors/api/v2/entries/${entryId}`
     });
 
     return EnvoyAPI.getDataFromBody(body);
   }
+  /** 
+   * @param {string | number} entryId
+   * @param {{}} entry
+   * @returns {Promise<EnvoyObject>}
+   */
+  async patchEntry(entryId, entry) {
+    const body = await this.request({
+      method: 'PATCH',
+      url: `/a/visitors/api/v2/entries/${entry['entry-id']}`,
+      body: entry
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+  /** 
+   * @param {{}} entry
+   * @returns {Promise<EnvoyObject>}
+   */
+  async createEntry(entry) {
+    const body = await this.request({
+      method: 'POST',
+      url: `/a/visitors/api/v2/entries`,
+      body: entry
+    })
+
+    // Currently the route returns only a status code 204 for success. For now just return object indicating success.
+    return { "message" : "Success" };
+  }
+
 
   /**
    * Fetches a list of WorkSchedules.

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -581,6 +581,12 @@ class EnvoyAPI {
     return EnvoyAPI.getDataFromBody(body);
   }
   
+  /**
+   * Create an invite using the V1 API endpoint.
+   *
+   * @param {{}} invite
+   * @returns {Promise<EnvoyObject>}
+   */
   async createInviteV1(invite) {
     var options = {
       method: 'POST',
@@ -599,7 +605,33 @@ class EnvoyAPI {
 
     return EnvoyAPI.getDataFromBody(body);
   }
-  
+
+  /**
+   * Updates an invite.
+   *
+   * @param { number|string } inviteId
+   * @param {{}} invite
+   * @returns {Promise<EnvoyObject>}
+   */
+  async updateInviteV1(inviteId, invite) {
+    var options = {
+      method: 'POST',
+      url: this.newUrl + `/invites/${inviteId}`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      body: invite,
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
   /**
    * Updates an invite.
    *

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -237,6 +237,19 @@ class EnvoyAPI {
   }
 
   /**
+   * Fetches a list of WorkSchedules.
+   * @param {*} workSchedule 
+   */
+  async workSchedules(workSchedule) {
+    const body = await this.request({
+      method: 'GET',
+      url: `/api/v1/work-schedules`,
+      body: workSchedule,
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+  /**
    * Create a new work schedule for an employee.
    * @param {{}} workSchedule - Work object with locationId, email, expectedArrivalAt (UTC date time format)
    */

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -848,6 +848,53 @@ class EnvoyAPI {
   }
 
   /**
+   * Get a space by Id.
+   * @params { number|string }
+   * @returns {Promise<EnvoyObject[]>}
+   */
+  async space(spaceId) {
+    var options = {
+      method: 'GET',
+      url: this.newUrl + `/spaces/${spaceId}`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+  /**
+   * Get all spaces with option query params to further filter results.
+   * @params { {} } Object containing query params.
+   * @returns {Promise<EnvoyObject[]>}
+   */
+  async spaces(space) {
+    var options = {
+      method: 'GET',
+      url: this.newUrl + `/spaces`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      qs: space,
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+  /**
    * Updates the job.
    *
    * @param {string|uuid} jobId

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -1,4 +1,5 @@
 const request = require('request-promise-native');
+const axios = require('axios');
 const EnvoyResponseError = require('./EnvoyResponseError');
 
 /**

--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -47,6 +47,7 @@ class EnvoyAPI {
 
     this.token = token;
     this.baseUrl = process.env.ENVOY_BASE_URL || 'https://app.envoy.com';
+    this.newUrl = 'https://api.envoy.com/v1';
     this.request = request.defaults({
       headers: {
         Authorization: `Bearer ${token}`,
@@ -123,7 +124,7 @@ class EnvoyAPI {
   async companies() {
     var options = {
       'method': 'GET',
-      'url': 'https://api.envoy.com/v1/companies',
+      'url': this.newUrl + '/companies',
       'headers': {
         'Authorization': 'Bearer ' + this.token
       },
@@ -363,7 +364,7 @@ class EnvoyAPI {
   async workSchedule(workScheduleId) {
     var options = {
       method: 'GET',
-      url: `https://api.envoy.com/v1/work-schedules/${workScheduleId}`,
+      url: this.newUrl + `/work-schedules/${workScheduleId}`,
       headers: {
         Authorization: 'Bearer ' + this.token
       },
@@ -386,14 +387,14 @@ class EnvoyAPI {
   async workSchedules(workSchedule) {
     var options = {
       method: 'GET',
-      url: 'https://api.envoy.com/v1/work-schedules',
+      url: this.newUrl + '/work-schedules',
       headers: {
         Authorization: 'Bearer ' + this.token
       },
       body: workSchedule,
       json: true,
     };
-
+    console.log(options.url);
     const body = await request(options, function (error, response) {
       if (error) throw new Error(error);
       response.body;
@@ -410,7 +411,7 @@ class EnvoyAPI {
   async createWorkSchedule(workSchedule) {
     var options = {
       method: 'POST',
-      url: `https://api.envoy.com/v1/work-schedules`,
+      url: this.newUrl + `/work-schedules`,
       headers: {
         Authorization: 'Bearer ' + this.token
       },
@@ -434,7 +435,7 @@ class EnvoyAPI {
   deleteWorkSchedule = async (workScheduleId) => {
     var options = {
       method: 'DELETE',
-      url: `https://api.envoy.com/v1/work-schedules/${workScheduleId}`,
+      url: this.newUrl + `/work-schedules/${workScheduleId}`,
       headers: {
         Authorization: 'Bearer ' + this.token
       },
@@ -459,7 +460,7 @@ class EnvoyAPI {
   async checkInWork(workScheduleId) {
     var options = {
       method: 'POST',
-      url: `https://api.envoy.com/v1/work-schedules/${workScheduleId}/checkin`,
+      url: this.newUrl + `/work-schedules/${workScheduleId}/checkin`,
       headers: {
         Authorization: 'Bearer ' + this.token
       },
@@ -483,7 +484,7 @@ class EnvoyAPI {
    async checkOutWork(workScheduleId) {
     var options = {
       method: 'POST',
-      url: `https://api.envoy.com/v1/work-schedules/${workScheduleId}/checkout`,
+      url: this.newUrl + `/work-schedules/${workScheduleId}/checkout`,
       headers: {
         Authorization: 'Bearer ' + this.token
       },
@@ -497,6 +498,52 @@ class EnvoyAPI {
 
     // Returns status 204 so body has no content.
     return { message: 'Successfully checked out.' }
+  }
+
+  /**
+   * @param { number|string } Invite ID.
+   * @returns {Promise<EnvoyObject>}
+   */
+   async getInvite(inviteId) {
+    var options = {
+      method: 'GET',
+      url: this.newUrl + `/invites/${inviteId}`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+    
+    return EnvoyAPI.getDataFromBody(body);
+  }
+
+
+  /**
+   * @param { {} } invite Object containing query params. 
+   * @returns {Promise<EnvoyObject>}
+   */
+  async getInvites(invite){
+    var options = {
+      method: 'GET',
+      url: this.newUrl + `/invites`,
+      headers: {
+        Authorization: 'Bearer ' + this.token
+      },
+      qs: invite,
+      json: true
+    };
+
+    const body = await request(options, function (error, response) {
+      if (error) throw new Error(error);
+      response.body;
+    });
+    
+    return EnvoyAPI.getDataFromBody(body);
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,6 +199,27 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1100,6 +1121,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "forever-agent": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/envoy/envoy-integrations-sdk-nodejs#readme",
   "dependencies": {
+    "axios": "^0.27.2",
     "body-parser": "^1.19.0",
     "dotenv": "^8.1.0",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
Updated EnvoyAPI with additional methods to be consistent with the public APIs we have available.

Also added axios package. In the future we should update the requests to axios to move away from the nodeJS Request library which is now deprecated.