### PR TITLE
Remove unusable plugin install endpoint

### DIFF
--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -363,24 +363,6 @@ class EnvoyAPI {
   }
 
   /**
-   * Fetches a plugin install.
-   *
-   * @param {number} installId
-   * @returns {Promise<{}>}
-   */
-  async getPluginInstall(installId) {
-    return new Promise((resolve, reject) => {
-      this.request({
-        method: 'GET',
-        url: `/api/v2/plugin-services/installs/${installId}`,
-      }).then(body => resolve(EnvoyAPI.getDataFromBody(body)))
-        .catch((error) => {
-          EnvoyAPI.safeRequestsError(error).catch((err) => reject(err));
-        });
-    });
-  }
-
-  /**
    * Gets the plugin install's config.
    *
    * @param {number} installId

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@envoy/envoy-integrations-sdk",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@envoy/envoy-integrations-sdk",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envoy/envoy-integrations-sdk",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Envoy-web does not expose this information via this endpoint, so to avoid confusion, I'm removing the function entirely.