### PR TITLE
feat(login): Adding scopes option to login function

### DIFF
--- a/lib/EnvoyAPI.js
+++ b/lib/EnvoyAPI.js
@@ -453,6 +453,17 @@ class EnvoyAPI {
    * @param {string} [secret=process.env.ENVOY_CLIENT_SECRET]
    */
   static login(id = process.env.ENVOY_CLIENT_ID, secret = process.env.ENVOY_CLIENT_SECRET) {
+    return EnvoyAPI.login(id,  secret, ['plugin', 'token.refresh'])
+  }
+
+  /**
+   * Gets an access token using client_credentials as the grant type.
+   *
+   * @param {string} [id=process.env.ENVOY_CLIENT_ID]
+   * @param {string} [secret=process.env.ENVOY_CLIENT_SECRET]
+   * @param {string[]} [scopes]
+   */
+  static login(id = process.env.ENVOY_CLIENT_ID, secret = process.env.ENVOY_CLIENT_SECRET, scopes) {
     const baseUrl = process.env.ENVOY_BASE_URL || 'https://app.envoy.com';
     return request({
       auth: {
@@ -465,7 +476,7 @@ class EnvoyAPI {
         grant_type: 'client_credentials',
         client_id: id,
         client_secret: secret,
-        scope: 'plugin,token.refresh',
+        scope: scopes.join(','),
       },
       url: '/a/auth/v0/token',
       baseUrl,
@@ -480,6 +491,16 @@ class EnvoyAPI {
     id = process.env.ENVOY_CLIENT_ID,
     secret = process.env.ENVOY_CLIENT_SECRET,
   ) {
+    return EnvoyAPI.loginAsUser(username, password, id,  secret, ['plugin','token.refresh'])
+  }
+
+  static loginAsUser(
+      username,
+      password,
+      id = process.env.ENVOY_CLIENT_ID,
+      secret = process.env.ENVOY_CLIENT_SECRET,
+      scopes,
+  ) {
     const baseUrl = process.env.ENVOY_BASE_URL || 'https://app.envoy.com';
     return request({
       auth: {
@@ -492,7 +513,7 @@ class EnvoyAPI {
         grant_type: 'password',
         username,
         password,
-        scope: 'plugin,token.refresh',
+        scope: scopes.join(','),
       },
       url: '/a/auth/v0/token',
       baseUrl,


### PR DESCRIPTION
**Context:**
Before we did not have the ability to specify the scope when creating the endpoint

With this we are adding new functions to the integration to do this. The `login`,  `loginAsUser` take in a list of scopes (string) that will be used to generate the token.
