### PR TITLE
Add isDisabled to EnvoyOption

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envoy/envoy-integrations-sdk",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "SDK for building Envoy integrations.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/internal/EnvoyOption.ts
+++ b/src/internal/EnvoyOption.ts
@@ -1,6 +1,7 @@
 type EnvoyOption = {
   label: string,
   value: string,
+  isDisabled?: boolean,
 };
 
 export default EnvoyOption;


### PR DESCRIPTION
The select component that the app store uses recognizes this and behaves accordingly.

Is this valid and supported, or it just happens to work and shouldn't be encouraged?