### PR TITLE
Update type and docs to clarify removing values from config in validation route handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ const { sub: visitorId } = await jwt.decode(token);
  */
 res.send({ foo: 'bar' }); // will save foo in the installation config.
 // or
+res.send({ foo: null }); // will remove foo from the installation config.
+// or
 res.sendFailed('This step has failed validation.'); // prevent the installer from progressing.
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import EnvoyResponse from './sdk/EnvoyResponse';
 import EnvoyStorageItem from './sdk/EnvoyStorageItem';
 import EnvoyUserAPI from './sdk/EnvoyUserAPI';
 import EnvoyPluginAPI from './sdk/EnvoyPluginAPI';
+import EnvoyValidationRouteResponseBody from './sdk/EnvoyValidationRouteResponseBody';
 
 import EnvoyJWT from './util/EnvoyJWT';
 import EnvoySignatureVerifier from './util/EnvoySignatureVerifier';
@@ -77,6 +78,7 @@ export {
   EnvoyStorageItem,
   EnvoyPluginAPI,
   EnvoyUserAPI,
+  EnvoyValidationRouteResponseBody,
   JSONAPIData,
   HttpStatus,
   entryEventBodyFactory,

--- a/src/sdk/EnvoyResponse.ts
+++ b/src/sdk/EnvoyResponse.ts
@@ -3,6 +3,7 @@ import EnvoyPluginJobAttachment from './EnvoyPluginJobAttachment';
 import EnvoyOptionsRouteResponseBody from '../internal/EnvoyOptionsRouteResponseBody';
 import EnvoySelectedValuesRouteResponseBody from '../internal/EnvoySelectedValuesRouteResponseBody';
 import EnvoyRemoteValueRouteResponseBody from '../internal/EnvoyRemoteValueRouteResponseBody';
+import EnvoyValidationRouteResponseBody from './EnvoyValidationRouteResponseBody';
 
 /**
  * Use to type your `res` object in Envoy event handlers.
@@ -44,3 +45,11 @@ export type EnvoyRemoteValueRouteResponse = EnvoyResponse<EnvoyRemoteValueRouteR
  * @category Response
  */
 export type EnvoySelectedValuesRouteResponse = EnvoyResponse<EnvoySelectedValuesRouteResponseBody>;
+
+/**
+ * Use to type your `res` object in Envoy "validation URL" route handlers.
+ * The response body should likely include validated values from the request payload
+ * and optionally additional config values.
+ * @category Response
+ */
+export type EnvoyValidationRouteResponse<Config> = EnvoyResponse<EnvoyValidationRouteResponseBody<Config>>;

--- a/src/sdk/EnvoyValidationRouteResponseBody.ts
+++ b/src/sdk/EnvoyValidationRouteResponseBody.ts
@@ -1,0 +1,12 @@
+type Nullable<T> = {
+  [P in keyof T]: T[P] | null;
+};
+
+/**
+ * Config to merge with existing config.
+ * It should likely include validated values from the request payload and optionally additional config values.
+ *
+ * @category Response Body
+ */
+type EnvoyValidationRouteResponseBody<Config> = Nullable<Partial<Config>>;
+export default EnvoyValidationRouteResponseBody;

--- a/src/sdk/handlers.ts
+++ b/src/sdk/handlers.ts
@@ -24,6 +24,10 @@ import EnvoyResponse, {
 
 type SomeObject = Record<string, unknown>;
 
+type Nullable<T> = {
+  [P in keyof T]: T[P] | null;
+};
+
 type Result = Promise<void> | void;
 
 /**
@@ -94,7 +98,7 @@ export type SelectedValuesRouteHandler<Config = SomeObject, Additions = SomeObje
  * @category Handler
  */
 export type ValidationRouteHandler<Config = SomeObject, Payload = SomeObject, Additions = SomeObject> =
-  (req: EnvoyValidationRouteRequest<Payload, Config> & Additions, res: EnvoyResponse<Partial<Config>>) => Result;
+  (req: EnvoyValidationRouteRequest<Payload, Config> & Additions, res: EnvoyResponse<Nullable<Partial<Config>>>) => Result;
 
 /**
  * Wraps any express.js-based handlers

--- a/src/sdk/handlers.ts
+++ b/src/sdk/handlers.ts
@@ -20,13 +20,10 @@ import EnvoyResponse, {
   EnvoyOptionsRouteResponse,
   EnvoyRemoteValueRouteResponse,
   EnvoySelectedValuesRouteResponse,
+  EnvoyValidationRouteResponse,
 } from './EnvoyResponse';
 
 type SomeObject = Record<string, unknown>;
-
-type Nullable<T> = {
-  [P in keyof T]: T[P] | null;
-};
 
 type Result = Promise<void> | void;
 
@@ -98,7 +95,7 @@ export type SelectedValuesRouteHandler<Config = SomeObject, Additions = SomeObje
  * @category Handler
  */
 export type ValidationRouteHandler<Config = SomeObject, Payload = SomeObject, Additions = SomeObject> =
-  (req: EnvoyValidationRouteRequest<Payload, Config> & Additions, res: EnvoyResponse<Nullable<Partial<Config>>>) => Result;
+  (req: EnvoyValidationRouteRequest<Payload, Config> & Additions, res: EnvoyValidationRouteResponse<Config>) => Result;
 
 /**
  * Wraps any express.js-based handlers


### PR DESCRIPTION
To remove an item from the saved `config`, you can set the item's key to `null`.