### PR TITLE
add invitee-employee and creator to invite payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envoy/envoy-integrations-sdk",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "SDK for building Envoy integrations.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/payloads/InvitePayload.ts
+++ b/src/payloads/InvitePayload.ts
@@ -58,8 +58,14 @@ type InvitePayload = {
     'agreeable-ndas'?: {
       data: Array<JSONAPIData<'agreeable-ndas'>>,
     },
-    'tenant'?: {
+    tenant?: {
       data: JSONAPIData<'tenants'>,
+    },
+    'invitee-employee'?: {
+      data: JSONAPIData<'employees'>,
+    },
+    creator?: {
+      data: JSONAPIData<'users'>,
     },
   }
 };


### PR DESCRIPTION
The invite resource payload contains a couple more relationships that can be sent to authz to check if a user can view an invite