### PR TITLE
Throw more specific error in response interceptor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@envoy/envoy-integrations-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@envoy/envoy-integrations-sdk",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "ISC",
       "dependencies": {
         "@types/dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envoy/envoy-integrations-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "SDK for building Envoy integrations.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/base/EnvoyAPI.ts
+++ b/src/base/EnvoyAPI.ts
@@ -74,8 +74,10 @@ export default class EnvoyAPI {
 
       (included || [])
         .concat(modelOrModels)
-        .filter((model: JSONAPIData | null) => model !== null)
         .forEach((model: JSONAPIData) => {
+          if (!model) {
+            throw new Error('Received unexpected response from Envoy. Consider updating to the latest SDK version.');
+          }
           this.dataLoader.prime({ type: model.type, id: model.id }, model);
           const alias = TYPE_ALIASES.get(model.type);
           if (alias) {

--- a/src/base/EnvoyAPI.ts
+++ b/src/base/EnvoyAPI.ts
@@ -74,6 +74,7 @@ export default class EnvoyAPI {
 
       (included || [])
         .concat(modelOrModels)
+        .filter((model: JSONAPIData | null) => model !== null)
         .forEach((model: JSONAPIData) => {
           this.dataLoader.prime({ type: model.type, id: model.id }, model);
           const alias = TYPE_ALIASES.get(model.type);

--- a/src/base/EnvoyAPI.ts
+++ b/src/base/EnvoyAPI.ts
@@ -76,7 +76,7 @@ export default class EnvoyAPI {
         .concat(modelOrModels)
         .forEach((model: JSONAPIData) => {
           if (!model) {
-            throw new Error('Received unexpected response from Envoy. Consider updating to the latest SDK version.');
+            throw new Error('The data you are looking for may not exist.');
           }
           this.dataLoader.prime({ type: model.type, id: model.id }, model);
           const alias = TYPE_ALIASES.get(model.type);


### PR DESCRIPTION
Calls to storage where the field doesn't exist return an array with a single null element. That causes an error when trying to access .type

~~I think this is a bug fix, but please let me know if it's not, or it's a breaking change a la
![image](https://github.com/user-attachments/assets/f2bfceb4-6e50-48b7-888d-fe48b7610399)~~

Update: Confirmed there are places we rely on this behavior, so instead of not throwing, we'll throw a more informative error. And opened https://github.com/envoy/envoy-integrations-sdk-nodejs/pull/76 to avoid the error in the next major version.
