### PR TITLE
[v3] Filter out nulls in response interceptor

### DIFF
--- a/src/base/EnvoyAPI.ts
+++ b/src/base/EnvoyAPI.ts
@@ -74,6 +74,7 @@ export default class EnvoyAPI {
 
       (included || [])
         .concat(modelOrModels)
+        .filter((model: JSONAPIData | null) => model !== null)
         .forEach((model: JSONAPIData) => {
           this.dataLoader.prime({ type: model.type, id: model.id }, model);
           const alias = TYPE_ALIASES.get(model.type);


### PR DESCRIPTION
Calls to storage where the field doesn't exist return an array with a single null element. That throws an error when trying to access .type