### PR TITLE
Fix deprecated actions/cache v2 in package workflow

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -17,7 +17,7 @@ jobs:
         run: |
           echo "::set-output name=version::$(node --version)"
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-node-modules
         with:
           path: node_modules


### PR DESCRIPTION
## Summary
- Updates `actions/cache` from deprecated v2 to v4 in the package.yaml workflow
- Fixes the deprecation warning that was causing workflow failures

## Test plan
- [ ] Verify workflow runs without deprecation warnings
- [ ] Confirm caching still works correctly with v4

🤖 Generated with [Claude Code](https://claude.ai/code)